### PR TITLE
Fix libc6 problem with Atom CPUS, closes #1, closes #2, closes #3

### DIFF
--- a/apache2/x86/.gitattributes
+++ b/apache2/x86/.gitattributes
@@ -1,0 +1,3 @@
+*.bin filter=lfs diff=lfs merge=lfs -text
+*.tar.* filter=lfs diff=lfs merge=lfs -text
+*.deb filter=lfs diff=lfs merge=lfs -text

--- a/apache2/x86/Apache2_2.2.34-x86-0.0.1.bin
+++ b/apache2/x86/Apache2_2.2.34-x86-0.0.1.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cc0d60b96f286266777863cf4afa7b6f4f5b68684bf7e00757a839cd24461b2
-size 26363904

--- a/apache2/x86/Apache2_2.2.34-x86-0.2.0.bin
+++ b/apache2/x86/Apache2_2.2.34-x86-0.2.0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfbd02e17d66e5e7f91bdce0cad56d5e4a05ac3d59bde6b2c87045d91cce0cf2
+size 24961024

--- a/apache2/x86/debs/apache2-mpm-prefork_2.2.34-0+rnx4_i386.deb
+++ b/apache2/x86/debs/apache2-mpm-prefork_2.2.34-0+rnx4_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88a7b446053fb09fc678a6ec260a357f801f21d8edc6bb67902e573267e32350
-size 2540

--- a/apache2/x86/debs/apache2-mpm-prefork_2.2.34-0+rnx6_i386.deb
+++ b/apache2/x86/debs/apache2-mpm-prefork_2.2.34-0+rnx6_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b52575d376ba6fd52d50fff54960c961c77851fb1d7a3772617aca47ee5b2db
+size 2344

--- a/apache2/x86/debs/apache2-utils_2.2.34-0+rnx4_i386.deb
+++ b/apache2/x86/debs/apache2-utils_2.2.34-0+rnx4_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba0b53e5a7d91d6fad4772fd864bbe86f11fa2a28e5caaa8ecf1df0825643d9c
-size 166234

--- a/apache2/x86/debs/apache2-utils_2.2.34-0+rnx6_i386.deb
+++ b/apache2/x86/debs/apache2-utils_2.2.34-0+rnx6_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b34286e2fd15a00e4426cd16080e7b2ca1713d4282f313c5c0f6404aae0f5e5e
+size 179742

--- a/apache2/x86/debs/apache2.2-bin_2.2.34-0+rnx4_i386.deb
+++ b/apache2/x86/debs/apache2.2-bin_2.2.34-0+rnx4_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:070d4826dd3478884f8ac6f5e81c2c9d281cec6c9de5db8c080138068fc633be
-size 897214

--- a/apache2/x86/debs/apache2.2-bin_2.2.34-0+rnx6_i386.deb
+++ b/apache2/x86/debs/apache2.2-bin_2.2.34-0+rnx6_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:174dee81d64e13094e51ac2746c6b2b16da717ab642151dc303fa96e63969ce8
+size 1979638

--- a/apache2/x86/debs/apache2.2-common_2.2.34-0+rnx4_i386.deb
+++ b/apache2/x86/debs/apache2.2-common_2.2.34-0+rnx4_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:358fe7f957411b788f9b4e08f296581ebef912b8ffd4094bac410d33f79a491f
-size 296050

--- a/apache2/x86/debs/apache2.2-common_2.2.34-0+rnx6_i386.deb
+++ b/apache2/x86/debs/apache2.2-common_2.2.34-0+rnx6_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddc329006259434c1d0037bec597093feb86bd905871c34fcb91585a8fe5de3f
+size 326168

--- a/apache2/x86/debs/apache2_2.2.34-0+rnx4_i386.deb
+++ b/apache2/x86/debs/apache2_2.2.34-0+rnx4_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6e37ae827d18b63b95750c33856b0d2c3ed14eb72ba7777e4784ed2422a931c
-size 1516

--- a/apache2/x86/debs/apache2_2.2.34-0+rnx6_i386.deb
+++ b/apache2/x86/debs/apache2_2.2.34-0+rnx6_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a8a1422e3fbfce2d3d6827aa5003bf18c91119432758347f5dbf13ab90b11a4
+size 1390

--- a/apache2/x86/debs/findutils_4.2.28-1etch1.1_i386.deb
+++ b/apache2/x86/debs/findutils_4.2.28-1etch1.1_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41de1e7eac25f6ca5b39992260a257d761c86b48a63263076e5e12a31f4787f7
-size 348786

--- a/apache2/x86/debs/findutils_4.4.0-2+rnx1_i386.deb
+++ b/apache2/x86/debs/findutils_4.4.0-2+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e806326f72a72fbb93c77318b3026c78e6312ccce45ef2a0e62b7adb472b5c26
+size 540342

--- a/apache2/x86/debs/libapr1_1.4.6-3+deb7u1+rnx1_i386.deb
+++ b/apache2/x86/debs/libapr1_1.4.6-3+deb7u1+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1679bf4d0be6422c839b2e38fc4997c289a286d2733a4b287473a6db21d90726
+size 99192

--- a/apache2/x86/debs/libapr1_1.5.2-3.0rnx2_i386.deb
+++ b/apache2/x86/debs/libapr1_1.5.2-3.0rnx2_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44f51cb981ff90ea60f1b81cd292f71322d71ac10ebd657506d0b8f9f7e187e9
-size 107166

--- a/apache2/x86/debs/libaprutil1-dbd-sqlite3_1.3.9+dfsg-5+rnx1_i386.deb
+++ b/apache2/x86/debs/libaprutil1-dbd-sqlite3_1.3.9+dfsg-5+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:248c9ac1125d3ff4669941111e57afbabdce424af5de7f0cdbd3cdc94afc2903
+size 27358

--- a/apache2/x86/debs/libaprutil1-dbd-sqlite3_1.5.4-1.0rnx2_i386.deb
+++ b/apache2/x86/debs/libaprutil1-dbd-sqlite3_1.5.4-1.0rnx2_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5bbcf4075fa28bd9e20f19c76ce02d68ae7f855430c6e0e0eeb81841a2e6a31f
-size 19334

--- a/apache2/x86/debs/libaprutil1-ldap_1.3.9+dfsg-5+rnx1_i386.deb
+++ b/apache2/x86/debs/libaprutil1-ldap_1.3.9+dfsg-5+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb0501f9ce6a0b28026cb9c7afdc58c0b669b71d0f5849299c69ec338d4ed4c2
+size 25330

--- a/apache2/x86/debs/libaprutil1-ldap_1.5.4-1.0rnx2_i386.deb
+++ b/apache2/x86/debs/libaprutil1-ldap_1.5.4-1.0rnx2_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca01c24a2d616cfcc71bdafd59296852d54406020abbc87c0efa56dfe08dbaee
-size 17338

--- a/apache2/x86/debs/libaprutil1_1.3.9+dfsg-5+rnx1_i386.deb
+++ b/apache2/x86/debs/libaprutil1_1.3.9+dfsg-5+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e705709ace4d865d6bc5502197333dfb27c554e9f8e9d221b0e6733931a3a2db
+size 85166

--- a/apache2/x86/debs/libaprutil1_1.5.4-1.0rnx2_i386.deb
+++ b/apache2/x86/debs/libaprutil1_1.5.4-1.0rnx2_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94a5186a407306b7a3af449569bb9959b1ec66291c3498e3bb9527c8bf74df50
-size 91772

--- a/apache2/x86/debs/libc-bin_2.13-38+deb7u10+rnx1_i386.deb
+++ b/apache2/x86/debs/libc-bin_2.13-38+deb7u10+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7c023bb1c4eb683d57ebc76f368a6a8f017a3f346f0609b1ab646be31e6eb1e
+size 1242074

--- a/apache2/x86/debs/libc-bin_2.19-18+deb8u10_i386.deb
+++ b/apache2/x86/debs/libc-bin_2.19-18+deb8u10_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4bb60abdb5643d27a15bcbcdf5f3870e9b0cb7286a35d47f5a305725ae6b47f
-size 1231542

--- a/apache2/x86/debs/libc6-amd64_2.13-38+deb7u10+rnx1_i386.deb
+++ b/apache2/x86/debs/libc6-amd64_2.13-38+deb7u10+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20904a0a8a9a93a166f726942a3036469517ad7e3c673551ed8e5d41a19f07b9
+size 4434876

--- a/apache2/x86/debs/libc6-amd64_2.19-18+deb8u10_i386.deb
+++ b/apache2/x86/debs/libc6-amd64_2.19-18+deb8u10_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec9f240edde591e086e5c9d7a9ff8c6b77d9e9ebde1257f483f7ecee40b0c338
-size 4902530

--- a/apache2/x86/debs/libc6-i686_2.13-38+deb7u10+rnx1_i386.deb
+++ b/apache2/x86/debs/libc6-i686_2.13-38+deb7u10+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7043e98a7914116ad6256dfcffeb2e47bbe669adfea66528636840ce28a469d3
+size 1348106

--- a/apache2/x86/debs/libc6-i686_2.19-18+deb8u10_i386.deb
+++ b/apache2/x86/debs/libc6-i686_2.19-18+deb8u10_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2e097fdc454da56e716060832acbf4616b8d65ce22ef2fef320b6a636b9dbb5
-size 1484738

--- a/apache2/x86/debs/libc6_2.13-38+deb7u10+rnx1_i386.deb
+++ b/apache2/x86/debs/libc6_2.13-38+deb7u10+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b53500a840fce1ea5adcf338e2062508190e0035da279712da1bf1a39d94a90e
+size 4079178

--- a/apache2/x86/debs/libc6_2.19-18+deb8u10_i386.deb
+++ b/apache2/x86/debs/libc6_2.19-18+deb8u10_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4497d0280d1c9929a1e64bad222045c9c49f48dde8cd358825793661291b9f40
-size 4176316

--- a/apache2/x86/debs/libcap2_2.22-1.2+rnx1_i386.deb
+++ b/apache2/x86/debs/libcap2_2.22-1.2+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59aa7c0e2f21e5589039b39d1546cfbaaa824357fad3a606c430ca5d761d9a75
+size 13640

--- a/apache2/x86/debs/libcap2_2.22-1.2rnx0_i386.deb
+++ b/apache2/x86/debs/libcap2_2.22-1.2rnx0_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8b803e22e6c8dbe8afe891c3d5071ca227a8f838a5805bc75d06e5d5ffecfb8
-size 15034

--- a/apache2/x86/debs/libdb5.3_5.3.28-9.0rnx1_i386.deb
+++ b/apache2/x86/debs/libdb5.3_5.3.28-9.0rnx1_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:574e64332a84231641fa9aaa64ba6bd45a1806176411d81e983174bf92b1450c
-size 721084

--- a/apache2/x86/debs/libexpat1_2.1.0-6+deb8u1_i386.deb
+++ b/apache2/x86/debs/libexpat1_2.1.0-6+deb8u1_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6029ad0781895b13696da066e82ee53a4ceecac5e4b4ec2817894ea5d44b514d
-size 83708

--- a/apache2/x86/debs/liblzma2_5.0.0-2~bpo50+1.0rnx1_i386.deb
+++ b/apache2/x86/debs/liblzma2_5.0.0-2~bpo50+1.0rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7175ecf7cffc25ad081d90c90f19ce81c420ee80751f78341ad1cdbee65f772a
+size 181950

--- a/apache2/x86/debs/liblzma2_5.0.0-2~bpo50+1_i386.deb
+++ b/apache2/x86/debs/liblzma2_5.0.0-2~bpo50+1_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:51000b5005057796c20e90a3da9bb491af18bd867b238efe95e61678813aae6b
-size 183758

--- a/apache2/x86/debs/libpcre3_8.39-3+rnx1_i386.deb
+++ b/apache2/x86/debs/libpcre3_8.39-3+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303d9e13f52c25714c00b9f0c09049d8db5d8510915c0f903646f39ec839ce97
+size 351058

--- a/apache2/x86/debs/libpcre3_8.39-4~rnx.1_i386.deb
+++ b/apache2/x86/debs/libpcre3_8.39-4~rnx.1_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46d9f4bf3812e74e506eb6819908046c4071f59b0af3b6f393ad00c047062110
-size 357464

--- a/apache2/x86/debs/libssl1.0.0_1.0.1k-3+deb8u2.0rnx1_i386.deb
+++ b/apache2/x86/debs/libssl1.0.0_1.0.1k-3+deb8u2.0rnx1_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e737d58b8ef1776205ebe082ed90e868478557861151cf07f347b57d9213a055
-size 10773756

--- a/apache2/x86/debs/libssl1.0.0_1.0.2l-1~bpo8+1+rnx2_i386.deb
+++ b/apache2/x86/debs/libssl1.0.0_1.0.2l-1~bpo8+1+rnx2_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22d55953a9f86e4c48560f16ea4bf3166de303019a02e70bd5d3275aa97626ec
+size 2875074

--- a/apache2/x86/debs/libuuid1_2.25.2-6.0rnx1_i386.deb
+++ b/apache2/x86/debs/libuuid1_2.25.2-6.0rnx1_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42fde99db7f56b308566d3a217b0edc710ff63947d306b87e968856b0dfc5587
-size 65964

--- a/apache2/x86/debs/locales_2.13-38+deb7u10+rnx1_all.deb
+++ b/apache2/x86/debs/locales_2.13-38+deb7u10+rnx1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da144bb3e438c2eb64b645cdf3973d11f715de4aba943fa2b3964e1ed9d47682
+size 5717294

--- a/apache2/x86/debs/locales_2.19-18+deb8u10_all.deb
+++ b/apache2/x86/debs/locales_2.19-18+deb8u10_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4cccfb89736fce93b83a759dd26d49f7f72bf42dde8c92b754a4304fa46a1d1
-size 6145604

--- a/apache2/x86/debs/multiarch-support_2.13-38+deb7u10+rnx1_i386.deb
+++ b/apache2/x86/debs/multiarch-support_2.13-38+deb7u10+rnx1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:931a275f329e5740007c70c46d1da71fc1cc933be4a74684b24ce1377a64e7f7
+size 152298

--- a/apache2/x86/debs/multiarch-support_2.19-18+deb8u10_i386.deb
+++ b/apache2/x86/debs/multiarch-support_2.19-18+deb8u10_i386.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b1b4f99d7c7a7b618b22678ab42dbe47f7d90562133b921f9f3562d08a7be30
-size 180490


### PR DESCRIPTION
- downgraded libc6 from 2.13 to 2.19
- updated findutils from 4.2.28 to 4.4
- updated OpenSSL to 1.0.2l
- fixed SSLCipher replacement in /etc/frontview/apache/httpd.conf